### PR TITLE
Adds translations for team update feature

### DIFF
--- a/resources/en/translation.json
+++ b/resources/en/translation.json
@@ -577,7 +577,7 @@
     "fixTeams": { 
         "description": "The teams for match {{id}} have been updated.",
         "invalid": {
-            "lobbyMismatch": "Members mentioned in the command must match the members mentioned in the command!"
+            "lobbyMismatch": "Members mentioned in the command must match the members in the lobby!"
         }
     }
 }

--- a/resources/en/translation.json
+++ b/resources/en/translation.json
@@ -577,7 +577,7 @@
     "fixTeams": { 
         "description": "The teams for match {{id}} have been updated.",
         "invalid": {
-            "lobbyMismatch": "Members mentioned in the command must match the members mentioned in the command!",
+            "lobbyMismatch": "Members mentioned in the command must match the members mentioned in the command!"
         }
     }
 }

--- a/resources/en/translation.json
+++ b/resources/en/translation.json
@@ -573,5 +573,11 @@
         "description": "You can now report the score correctly.",
         "error": "You can only undo a match that has been reported or cancelled.",
         "title": "Match {{id}} was undone."
+    },
+    "fixTeams": { 
+        "description": "The teams for match {{id}} have been updated.",
+        "invalid": {
+            "lobbyMismatch": "Members mentioned in the command must match the members mentioned in the command!",
+        }
     }
 }


### PR DESCRIPTION
Adds translations related to updating teams in a match.

This includes descriptions and error messages to inform users about the outcome of team update actions and potential issues.